### PR TITLE
Feature: emit event when a plug is disabled/enabled or edited

### DIFF
--- a/api/plugs/src/plugs/plugs.service.ts
+++ b/api/plugs/src/plugs/plugs.service.ts
@@ -176,7 +176,7 @@ export class PlugsService {
     return this.format(created.toJSON());
   }
 
-  async update(id: string, plug: PlugSubmitDto): Promise<Plug> {
+  async update(id: string, plug: PlugSubmitDto): Promise<PlugWithId> {
     const updated = await this.plugsModel
       .findByIdAndUpdate(id, plug)
       .lean()


### PR DESCRIPTION
# Description

When a plug is edited (or enabled/disabled), a message is emitted on plug_event_SERVICE_disabled queue to allow microservices to unregister their webhooks

# Changes include

- [ ] Chore (change that needs to be done without effects on features)
- [ ] Bugfix (change that solves an issue)
- [x] New feature (change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Changes Type

- [x] backend update
- [ ] mobile update
- [ ] web update

# Breaking changes

Services now need to implement those queues

# Checklist

- [x] I have assigned this PR to the reviewer
- [x] I have added at least 1 reviewer
- [ ] I have updated the documentation
- [ ] I have updated the README.md
- [x] I have manually tested the code
- [ ] I have added/updated tests
