### PR TITLE
Feature: color field in service config

### DIFF
--- a/api/github/src/config/github.config.ts
+++ b/api/github/src/config/github.config.ts
@@ -2,6 +2,7 @@ export default {
   name: 'github',
   authType: 'oauth2',
   icon: '/images/github_icon.png',
+  color: '#080808',
   events: [],
   actions: [],
 };

--- a/api/plugs/src/services/dto/InitializeRequest.dto.ts
+++ b/api/plugs/src/services/dto/InitializeRequest.dto.ts
@@ -1,7 +1,7 @@
 import {
   IsArray,
   IsBoolean,
-  IsEnum,
+  IsEnum, IsNotEmpty,
   IsString,
   ValidateNested,
 } from 'class-validator';
@@ -23,12 +23,14 @@ export enum ElementType {
 
 export class Variable {
   @IsString()
+  @IsNotEmpty()
   key: string;
 
   @IsEnum(ElementType)
   type: ElementType;
 
   @IsString()
+  @IsNotEmpty()
   displayName: string;
 
   @IsString()
@@ -37,12 +39,14 @@ export class Variable {
 
 export class Field {
   @IsString()
+  @IsNotEmpty()
   key: string;
 
   @IsEnum(ElementType)
   type: ElementType;
 
   @IsString()
+  @IsNotEmpty()
   displayName: string;
 
   @IsBoolean()
@@ -51,9 +55,11 @@ export class Field {
 
 export class EventDescription {
   @IsString()
+  @IsNotEmpty()
   id: string;
 
   @IsString()
+  @IsNotEmpty()
   name: string;
 
   @IsString()
@@ -72,9 +78,11 @@ export class EventDescription {
 
 export class ActionDescription {
   @IsString()
+  @IsNotEmpty()
   id: string;
 
   @IsString()
+  @IsNotEmpty()
   name: string;
 
   @IsString()
@@ -93,13 +101,19 @@ export class ActionDescription {
 
 export class InitializeRequestDto {
   @IsString()
+  @IsNotEmpty()
   name: string;
 
   @IsEnum(AuthType)
   authType: AuthType;
 
   @IsString()
+  @IsNotEmpty()
   icon: string;
+
+  @IsString()
+  @IsNotEmpty()
+  color: string;
 
   @IsArray()
   @ValidateNested()

--- a/api/plugs/src/services/schemas/service.schema.ts
+++ b/api/plugs/src/services/schemas/service.schema.ts
@@ -21,6 +21,9 @@ export class Service {
   icon: string;
 
   @Prop({ required: true })
+  color: string;
+
+  @Prop({ required: true })
   events: EventDescription[];
 
   @Prop({ required: true })

--- a/api/starton/src/config/starton.ts
+++ b/api/starton/src/config/starton.ts
@@ -2,6 +2,7 @@ export default {
   name: 'starton',
   authType: 'apiKey',
   icon: '/images/starton_icon.png',
+  color: '#060228',
   events: [
     {
       id: 'addressReceivedNativeTokens',

--- a/api/twitter/src/config/twitter.ts
+++ b/api/twitter/src/config/twitter.ts
@@ -2,6 +2,7 @@ export const twitter = {
   name: 'twitter',
   authType: 'oauth2',
   icon: '/images/twitter_icon.png',
+  color: '#1da0f2',
   events: [],
   actions: [
     {


### PR DESCRIPTION
# Description

Added a color field in service initialize DTO and schema to return background display color for the frontend.

# Changes include

- [ ] Chore (change that needs to be done without effects on features)
- [ ] Bugfix (change that solves an issue)
- [x] New feature (change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Changes Type

- [x] backend update
- [ ] mobile update
- [ ] web update

# Breaking changes

Services microservices now need to pass color in their initialize request

# Checklist

- [x] I have assigned this PR to the reviewer
- [x] I have added at least 1 reviewer
- [ ] I have updated the documentation
- [ ] I have updated the README.md
- [ ] I have manually tested the code
- [ ] I have added/updated tests
