### PR TITLE
Fix: returns all actions icons for plugs

### DIFF
--- a/api/plugs/src/plugs/plugs.service.ts
+++ b/api/plugs/src/plugs/plugs.service.ts
@@ -61,21 +61,61 @@ export class PlugsService {
           },
         },
         {
+          $unwind: '$actions',
+        },
+        {
           $lookup: {
             from: 'services',
-            let: {
-              names: '$actions.serviceName',
+            localField: 'actions.serviceName',
+            foreignField: 'name',
+            as: 'linked_services',
+          },
+        },
+        {
+          $group: {
+            _id: '$_id',
+            otherFields: { $first: '$$ROOT' },
+            actions: { $push: '$actions' },
+            linked_services: {
+              $push: '$linked_services',
             },
-            pipeline: [
-              {
-                $match: {
-                  $expr: {
-                    $in: ['$name', '$$names'],
-                  },
+          },
+        },
+        {
+          $addFields: {
+            icons: {
+              $map: {
+                input: '$linked_services',
+                as: 'service',
+                in: '$$service.icon',
+              },
+            },
+          },
+        },
+        {
+          $addFields: {
+            allIcons: {
+              $reduce: {
+                input: '$icons',
+                initialValue: [],
+                in: {
+                  $concatArrays: ['$$value', '$$this'],
                 },
               },
-            ],
-            as: 'actionsIcons',
+            },
+          },
+        },
+        {
+          $replaceRoot: {
+            newRoot: {
+              $mergeObjects: [
+                '$otherFields',
+                {
+                  actions: '$actions',
+                  allIcons: '$allIcons',
+                },
+              ],
+            },
           },
         },
         {
@@ -86,7 +126,7 @@ export class PlugsService {
             event: 1,
             actions: 1,
             icons: {
-              $concatArrays: ['$icons.icon', '$actionsIcons.icon'],
+              $concatArrays: ['$icons.icon', '$allIcons'],
             },
           },
         },
@@ -114,21 +154,61 @@ export class PlugsService {
           },
         },
         {
+          $unwind: '$actions',
+        },
+        {
           $lookup: {
             from: 'services',
-            let: {
-              names: '$actions.serviceName',
+            localField: 'actions.serviceName',
+            foreignField: 'name',
+            as: 'linked_services',
+          },
+        },
+        {
+          $group: {
+            _id: '$_id',
+            otherFields: { $first: '$$ROOT' },
+            actions: { $push: '$actions' },
+            linked_services: {
+              $push: '$linked_services',
             },
-            pipeline: [
-              {
-                $match: {
-                  $expr: {
-                    $in: ['$name', '$$names'],
-                  },
+          },
+        },
+        {
+          $addFields: {
+            icons: {
+              $map: {
+                input: '$linked_services',
+                as: 'service',
+                in: '$$service.icon',
+              },
+            },
+          },
+        },
+        {
+          $addFields: {
+            allIcons: {
+              $reduce: {
+                input: '$icons',
+                initialValue: [],
+                in: {
+                  $concatArrays: ['$$value', '$$this'],
                 },
               },
-            ],
-            as: 'actionsIcons',
+            },
+          },
+        },
+        {
+          $replaceRoot: {
+            newRoot: {
+              $mergeObjects: [
+                '$otherFields',
+                {
+                  actions: '$actions',
+                  allIcons: '$allIcons',
+                },
+              ],
+            },
           },
         },
         {
@@ -139,7 +219,7 @@ export class PlugsService {
             event: 1,
             actions: 1,
             icons: {
-              $concatArrays: ['$icons.icon', '$actionsIcons.icon'],
+              $concatArrays: ['$icons.icon', '$allIcons'],
             },
           },
         },


### PR DESCRIPTION
# Description

Reworkied Mongo db pipelines to fix a bug when a plug had 2 actions with the same service, the api was returning only on icon for both steps.

# Changes include

- [ ] Chore (change that needs to be done without effects on features)
- [x] Bugfix (change that solves an issue)
- [ ] New feature (change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Changes Type

- [x] backend update
- [ ] mobile update
- [ ] web update

# Checklist

- [x] I have assigned this PR to the reviewer
- [x] I have added at least 1 reviewer
- [ ] I have updated the documentation
- [ ] I have updated the README.md
- [x] I have manually tested the code
- [ ] I have added/updated tests
