### PR TITLE
Disconnect from starton destroys webhooks

### DIFF
--- a/api/starton/src/services/starton.service.ts
+++ b/api/starton/src/services/starton.service.ts
@@ -413,7 +413,7 @@ export class StartonService {
     );
   }
 
-  async deleteWatcher(apiKey: string, webhookId?: string): Promise<void> {
+  async deleteWatcher(apiKey: string, webhookId: string): Promise<void> {
     const startonApi = axios.create({
       baseURL: 'https://api.starton.io',
       headers: {

--- a/api/starton/src/services/webhook.service.ts
+++ b/api/starton/src/services/webhook.service.ts
@@ -24,6 +24,10 @@ export class WebHookService {
     });
   }
 
+  async findAllByUserId(userId: number): Promise<WebHookEntity[]> {
+    return this.webhookRepository.findBy({ userId });
+  }
+
   async create(
     uuid: string,
     userId: number,


### PR DESCRIPTION
# Description

When you disconnect from starton, it nows destroy all the created webhooks for the user

# Changes include

- [ ] Chore (change that needs to be done without effects on features)
- [ ] Bugfix (change that solves an issue)
- [X] New feature (change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Changes Type

- [X] backend update
- [ ] mobile update
- [ ] web update

# Checklist

- [X] I have assigned this PR to the reviewer
- [X] I have added at least 1 reviewer
- [X] I have updated the documentation
- [X] I have updated the README.md
- [X] I have manually tested the code
- [X] I have added/updated tests
