### PR TITLE
Fix: changed variables name for newVideoFromMyChannel

### DIFF
--- a/api/youtube/YouPlug/Services/PlugRegistration.cs
+++ b/api/youtube/YouPlug/Services/PlugRegistration.cs
@@ -34,10 +34,10 @@ namespace YouPlug.Services
                 new List<PlugDataDto.PlugVariable>()
                 {
                     new ("channelTitle", PlugDataDto.VariableType.String, "Channel Title", "The title of the channel that published the video"),
-                    new ("channelId", PlugDataDto.VariableType.String, "Stream ID", "The ID of the channel that published the video"),
-                    new ("streamTitle", PlugDataDto.VariableType.String, "Stream Title", "The published video title"),
-                    new ("streamId", PlugDataDto.VariableType.String, "Stream ID", "The ID of the published video"),
-                    new ("streamDescription", PlugDataDto.VariableType.String, "Video Description", "The description of the published video"),
+                    new ("channelId", PlugDataDto.VariableType.String, "Channel ID", "The ID of the channel that published the video"),
+                    new ("videoTitle", PlugDataDto.VariableType.String, "Video Title", "The published video title"),
+                    new ("videoId", PlugDataDto.VariableType.String, "Video ID", "The ID of the published video"),
+                    new ("videoDescription", PlugDataDto.VariableType.String, "Video Description", "The description of the published video"),
                 },
                 new List<PlugDataDto.PlugField>() { }
             );


### PR DESCRIPTION
# Description

Changed a bad config value in "newVideoFromMyChannel" that was report stream as variable instead of video.

# Changes include

- [ ] Chore (change that needs to be done without effects on features)
- [X] Bugfix (change that solves an issue)
- [ ] New feature (change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Changes Type

- [X] backend update
- [ ] mobile update
- [ ] web update

# Checklist

- [X] I have assigned this PR to the reviewer
- [X] I have added at least 1 reviewer
- [ ] I have updated the documentation
- [ ] I have updated the README.md
- [X] I have manually tested the code
- [ ] I have added/updated tests
